### PR TITLE
Avoid unnecessary files in dist / release files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 .scrutinizer.yml   export-ignore
 .travis.yml        export-ignore
 .styleci.yml       export-ignore
-phpunit.xml        export-ignore
+phpunit.xml.dist   export-ignore
 CHANGELOG.md       export-ignore
 CONTRIBUTING.md    export-ignore
+LICENSE.md         export-ignore
+README.md          export-ignore


### PR DESCRIPTION
I took the liberty to exclude the `LICENSE.md` file as it isn't really needed in dist files. Your position may differ on that.